### PR TITLE
Update GitHub username

### DIFF
--- a/nuxt/components/nav.vue
+++ b/nuxt/components/nav.vue
@@ -16,7 +16,7 @@
       <div class="navbar-item has-dropdown is-hoverable">
         <a class="navbar-link">Social & Services</a>
           <div class="navbar-dropdown is-boxed">
-            <a class="navbar-item" href="https://github.com/namoo-san">
+            <a class="navbar-item" href="https://github.com/nakashunsan">
               GitHub
             </a>
             <a class="navbar-item" href="https://www.facebook.com/ieto.sharu">

--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -26,7 +26,7 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link">Social & Services</a>
             <div class="navbar-dropdown is-boxed">
-              <a class="navbar-item" href="https://github.com/namoo-san">
+              <a class="navbar-item" href="https://github.com/nakashunsan">
                 🔧 GitHub
               </a>
               <a class="navbar-item" href="https://www.facebook.com/ieto.sharu">
@@ -59,7 +59,7 @@
     <footer class="footer">
       <div class="content has-text-centered">
         <p>
-          nakashun.com - @namoo-san
+          nakashun.com - @nakashunsan
         </p>
         <p>Deploy on <strong>Nuxt.js + Netlify⚡</strong></p>
       </div>

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -2,7 +2,7 @@
   "name": "my-portfolio",
   "version": "1.0.0",
   "description": "My portfolio website for netlify.",
-  "author": "namoo-san",
+  "author": "nakashunsan",
   "private": true,
   "scripts": {
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -14,7 +14,7 @@
           <!-- <NuxtLink to="/worklog" class = "button is-info is-large is-block">Worklog</NuxtLink> -->
           <!-- <NuxtLink to="/resume" class = "button is-success is-large is-block">Resume</NuxtLink> -->
           <NuxtLink to="/events" class="button is-warning is-large is-block">DJ Events</NuxtLink>
-          <a href="https://github.com/namoo-san" class="button is-dark is-large is-block">GitHub</a>
+          <a href="https://github.com/nakashunsan" class="button is-dark is-large is-block">GitHub</a>
           <a href="https://www.flickr.com/photos/namoo-san" class="button is-dark is-large is-block">Flickr</a>
         </div>
       </div>

--- a/nuxt/pages/resume/index.vue
+++ b/nuxt/pages/resume/index.vue
@@ -26,7 +26,7 @@
               <div class="media-content">
                 <div class="content">
                   <p>
-                    <strong>nakashun</strong> <small>@namoo-san</small>
+                    <strong>nakashun</strong> <small>@nakashunsan</small>
                     <small>(28)</small>
                     <br />
                   </p>

--- a/nuxt/pages/works.vue
+++ b/nuxt/pages/works.vue
@@ -65,7 +65,7 @@
               </div>
               <div class="media-content">
                 <p class="title is-4">Development</p>
-                <p class="subtitle is-6">@namoo-san</p>
+                <p class="subtitle is-6">@nakashunsan</p>
               </div>
             </div>
             <div class="content">


### PR DESCRIPTION
## What changed

- Updated GitHub profile links from `namoo-san` to `nakashunsan`
- Updated displayed GitHub handles and package author metadata
- Kept the Flickr username and repository name unchanged because they are separate identifiers

## Why

The GitHub account username changed from `namoo-san` to `nakashunsan`, leaving the site with stale links and identity metadata.

## Impact

Visitors are now directed to the current GitHub profile, and the site consistently displays the current GitHub username.

## Validation

- `git diff --check`
- Verified no stale GitHub URLs, displayed handles, or package author values remain
- `npm run build` (Node.js 24.0.0)
- `npm run lint` could not start because the existing script references a missing `nuxt/.gitignore`; direct ESLint execution also reports the existing missing `eslint-plugin-vue` dependency