### PR TITLE
Prevent top-page button layout shift

### DIFF
--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -67,7 +67,13 @@ useHead({
   padding-top: 15px;
 }
 
-.button{
+.links .button {
+  display: block;
+  width: 100%;
+  height: 60px;
+  padding: 12px 24px;
   margin-top: 10px;
+  font-size: 24px;
+  line-height: 1.5;
 }
 </style>


### PR DESCRIPTION
## What changed

- Added the critical layout properties for top-page buttons to the page-level CSS
- Matched Bulma's final large block button dimensions: full width, 60px height, 24px text, and 12px × 24px padding

## Why

The top-page component CSS is available in the initial HTML, while the full Bulma stylesheet is a large external asset. Before Bulma finished applying, the button links could briefly render as small inline elements and then jump to their final size.

Defining only the critical dimensions in the page CSS ensures the initial render already reserves the final button layout without duplicating Bulma's colors or broader component styling.

## Impact

The top-page buttons keep a stable size during initial page load, reducing visible layout shift.

## Validation

- `npm run lint`
- `npm run build`
- Tested the production server locally
- Confirmed the critical button rule is inlined in the initial HTML
- Confirmed all four buttons render at the final 347.9 × 60px dimensions