### PR TITLE
Remove SoundCloud from social links

### DIFF
--- a/nuxt/components/nav.vue
+++ b/nuxt/components/nav.vue
@@ -46,14 +46,6 @@
             </a>
             <a
               class="navbar-item"
-              href="https://soundcloud.com/djnm"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              SoundCloud
-            </a>
-            <a
-              class="navbar-item"
               href="https://twitter.com/ietosharu"
               target="_blank"
               rel="noopener noreferrer"

--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -32,9 +32,6 @@
               <a class="navbar-item" href="https://www.facebook.com/ieto.sharu">
                 😃 Facebook(Private)
               </a>
-              <a class="navbar-item" href="https://soundcloud.com/djnm">
-                🎧 SoundCloud
-              </a>
               <a class="navbar-item" href="https://twitter.com/ietosharu">
                 🐦 Twitter
               </a>


### PR DESCRIPTION
## What changed

- Removed the SoundCloud entry from the Social & Services menu in the default layout
- Removed the same entry from the reusable navigation component

## Why

The SoundCloud profile should no longer be presented as one of the site's social links.

## Impact

Visitors will no longer see or navigate to SoundCloud from either Social & Services menu implementation.

## Validation

- Confirmed no `SoundCloud` or `soundcloud.com` references remain
- `npm run lint`
- `npm run build`